### PR TITLE
Fixed Apiary documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,4 @@ Service running on desktop, listening on ws://localhost:6969/ for websocket comm
 wants to communicate with ID card reader.
 
 This service listen for websocket messages/commands documented on:
-https://app.apiary.io/czeidcardservice/editor
-
+https://czeidcardservice.docs.apiary.io/


### PR DESCRIPTION
Changed documentation link from private authenticated editor to public read-only API documentation.